### PR TITLE
Fix case-sensitive paths for project videos

### DIFF
--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -21,11 +21,11 @@ import aws from "../images/tools/aws.webp";
 import unity from "../images/tools/unity.webp";
 
 import DAIETpedia from "../images/projects/daietpedia.mp4";
-import CodepenAI from "../images/projects/codepenai.mp4";
+import CodepenAI from "../images/projects/CodepenAI.mp4";
 import PasswordInput from "../images/projects/password-input.mp4";
 import PlasticSlurg from "../images/projects/plastic-slurg.mp4";
 import Listr from "../images/projects/listr.mp4";
-import Sokoban from "../images/projects/sokoban.mp4";
+import Sokoban from "../images/projects/Sokoban.mp4";
 import SlidingPuzzles from "../images/projects/sliding-puzzles.mp4";
 import FlapryBlirb from "../images/projects/flapry-blirb.mp4";
 import ContactBook from "../images/projects/contact-book.mp4";


### PR DESCRIPTION
## Summary
- fix video import casing for CodepenAI and Sokoban

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden while fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_6883f4c5b20c832f9c1783202041036c