### PR TITLE
Fix dark mode text and video playback

### DIFF
--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -156,11 +156,13 @@ export default function Projects() {
             {project.media === "video" ? (
               <video
                 className="project-media"
-                src={assignVideo(project.title)}
                 autoPlay
                 muted
                 controls
-              ></video>
+                playsInline
+              >
+                <source src={assignVideo(project.title)} type="video/mp4" />
+              </video>
             ) : (
               <img
                 className="project-media"
@@ -233,11 +235,13 @@ export default function Projects() {
                   {project.media === "video" ? (
                     <video
                       className="project-media"
-                      src={assignVideo(project.title)}
                       autoPlay
                       muted
                       controls
-                    ></video>
+                      playsInline
+                    >
+                      <source src={assignVideo(project.title)} type="video/mp4" />
+                    </video>
                   ) : (
                     <img
                       className="project-media"

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -87,7 +87,7 @@
   list-style: none;
   padding: 25px;
   border-radius: var(--radius);
-  color: #111;
+  color: var(--mainColor);
   display: flex;
   flex-direction: column;
   gap: 20px;

--- a/src/styles/contact.css
+++ b/src/styles/contact.css
@@ -63,7 +63,7 @@ body.dark-theme .contact-info img {
   width: 48%;
   height: fit-content;
   background-color: var(--cardBackground);
-  color: #111;
+  color: var(--mainColor);
   padding: 25px;
   border-radius: var(--radius);
   box-shadow: 0 4px 10px var(--boxShadow);

--- a/src/styles/projects.css
+++ b/src/styles/projects.css
@@ -64,7 +64,7 @@ body.dark-theme .project-media {
   display: flex;
   flex-direction: column;
   gap: 30px;
-  color: #111;
+  color: var(--mainColor);
   font-size: 18px;
 }
 
@@ -215,7 +215,7 @@ body.dark-theme .project-media {
     display: flex;
     flex-direction: column;
     gap: 20px;
-    color: #111;
+    color: var(--mainColor);
     font-size: 18px;
   }
 

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -77,7 +77,7 @@ a {
 }
 
 .experience-link {
-  color: black;
+  color: var(--mainColor);
 }
 
 @media screen and (max-width: 850px) {


### PR DESCRIPTION
## Summary
- adjust card text colors to use CSS variables so dark mode looks correct
- update project video tags to use `<source>` and `playsInline`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6883fb287b04832f9e4c0e9d20a25fa4