### PR TITLE
Add MCP Servers tool icon

### DIFF
--- a/src/components/Tools.jsx
+++ b/src/components/Tools.jsx
@@ -24,6 +24,7 @@ import rag from "../images/tools/rag.webp";
 import azureai from "../images/tools/azureai.webp";
 import cosmosdb from "../images/tools/cosmosdb.webp";
 import mongodb from "../images/tools/mongodb.webp";
+import mcp from "../images/tools/mcp.PNG";
 
 export default function Tools() {
   const toolCategories = [
@@ -35,7 +36,8 @@ export default function Tools() {
         { name: "LLMs", image: llm, alt: "llm" },
         { name: "Embedding Models", image: embedding, alt: "embedding" },
         { name: "Vector Databases", image: vectorDb, alt: "vector database" },
-        { name: "RAG", image: rag, alt: "rag" }
+        { name: "RAG", image: rag, alt: "rag" },
+        { name: "MCP Servers", image: mcp, alt: "mcp servers" }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- import `mcp.PNG`
- list MCP Servers as a tool in the AI & Machine Learning section

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887f0a2abf4832fad5363ff4a5b6271